### PR TITLE
Preserve parameters

### DIFF
--- a/sfast/compilers/stable_diffusion_pipeline_compiler.py
+++ b/sfast/compilers/stable_diffusion_pipeline_compiler.py
@@ -79,7 +79,7 @@ def compile(m, config):
                         # raw freeze causes Tensor reference leak
                         # because the constant Tensors in the GraphFunction of
                         # the compilation unit are never freed.
-                        m = jit_utils.better_freeze(m)
+                        m = jit_utils.better_freeze(m, preserve_parameters=True)
                     modify_model(m)
 
                 if enable_cuda_graph:


### PR DESCRIPTION
This enables the preserve_parameter setting to preserve the parameters and not inline them as constants.

Unfortunately this is not exposed on the `torch.jit.freeze` so I had to copy paste some logic from pytorch.

This allows the user to update the weights on the original model (`model.unet.load_state_dict()`) without having to retrace and compile the module.

The only performance impact this has is that before the `_jit_pass_concat_frozen_linear` concatted a few `time_emb_proj` linear layers into one. So for the cuda graph inference there is no noticable impact in my testing. For the non-cuda-graph inference it might be slower because it has to traverse the model to get the weights.

This should also make the lora fusing with PEFT work correctly. But I have not tested that yet.
Also the freeze=False on the controlnet can probably be removed with this.