### PR TITLE
optimize perfermance of fused GEGLU

### DIFF
--- a/src/sfast/csrc/operators/cublas/CUDABlas.cc
+++ b/src/sfast/csrc/operators/cublas/CUDABlas.cc
@@ -480,7 +480,7 @@ void gemm<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half)) {
     // manually to be able to use tensor cores for FP16. On CUDA 11, this is no longer required.
     TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH));
 #else
-    cublasMath_t cublas_flags = CUBLAS_TF32_TENSOR_OP_MATH;
+    cublasMath_t cublas_flags = CUBLAS_DEFAULT_MATH;
     if (!at::globalContext().allowFP16ReductionCuBLAS()) {
       cublas_flags = static_cast<cublasMath_t>(cublas_flags | CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION);
     }

--- a/src/sfast/csrc/operators/cutlass/cutlass_dual_linear_kernel.cu
+++ b/src/sfast/csrc/operators/cutlass/cutlass_dual_linear_kernel.cu
@@ -29,7 +29,7 @@ namespace cutlass {
 
  maximum ulp error: 5735.81, maximum relative error: 3.8735e-4
 */
-template <typename T> CUTLASS_HOST_DEVICE T fast_erff(T x) {
+template <typename T> CUTLASS_HOST_DEVICE T fast_erf(T x) {
   T x2 = x * x;
   T tmp = (T)0.100646973f * x2 + (T)1.128759325f;
   x = tmp * x;
@@ -46,8 +46,8 @@ template <> struct GELU<half_t> {
   half_t operator()(half_t const &value) const {
     return cutlass::constants::half<half_t>() * value *
            (cutlass::constants::one<half_t>() +
-            cutlass::fast_erff(value *
-                               cutlass::constants::half_root_two<half_t>()));
+            cutlass::fast_erf(value *
+                              cutlass::constants::half_root_two<half_t>()));
   }
 };
 } // namespace thread
@@ -258,6 +258,11 @@ template <> struct cutlass_type<at::BFloat16> {
 
 template <typename scalar_t> struct acc_type {
   using type = scalar_t;
+};
+
+// NOTE: Significant precision loss if setting acc_type to half_t for GEGLU
+template <> struct acc_type<cutlass::half_t> {
+  using type = float;
 };
 
 template <> struct acc_type<cutlass::bfloat16_t> {

--- a/src/sfast/csrc/operators/cutlass/cutlass_dual_linear_kernel.cu
+++ b/src/sfast/csrc/operators/cutlass/cutlass_dual_linear_kernel.cu
@@ -261,6 +261,7 @@ template <typename scalar_t> struct acc_type {
 };
 
 // NOTE: Significant precision loss if setting acc_type to half_t for GEGLU
+// Maybe GELU is too sensitive to precision loss
 template <> struct acc_type<cutlass::half_t> {
   using type = float;
 };

--- a/src/sfast/csrc/operators/cutlass/cutlass_dual_linear_kernel.cu
+++ b/src/sfast/csrc/operators/cutlass/cutlass_dual_linear_kernel.cu
@@ -39,15 +39,15 @@ template <typename T> CUTLASS_HOST_DEVICE T fast_erff(T x) {
 namespace epilogue {
 namespace thread {
 
-template <> struct GELU<half> {
+template <> struct GELU<half_t> {
   static const bool kIsHeavy = true;
 
   CUTLASS_HOST_DEVICE
-  half operator()(half const &value) const {
-    return cutlass::constants::half<half>() * value *
-           (cutlass::constants::one<half>() +
+  half_t operator()(half_t const &value) const {
+    return cutlass::constants::half<half_t>() * value *
+           (cutlass::constants::one<half_t>() +
             cutlass::fast_erff(value *
-                               cutlass::constants::half_root_two<half>()));
+                               cutlass::constants::half_root_two<half_t>()));
   }
 };
 } // namespace thread

--- a/src/sfast/hooks/module_jit_hook.py
+++ b/src/sfast/hooks/module_jit_hook.py
@@ -68,7 +68,7 @@ class ModuleJITHook:
             else:
                 new_input_key = self.compiler.get_inputs_key(
                     self.call_impl, args, kwargs)
-                if hash(new_input_key) == hash(inputs_key):
+                if new_input_key == inputs_key:
                     # inputs not mutated
                     logger.info(f'Compiling {self.module.__class__.__name__}')
                     compiled = self.compiler.compile(self.call_impl, args,


### PR DESCRIPTION
During benchmarking SDXL model on A10, I found nearly 25% of the time is spent on computing fused GEGLU. Although the fused GEGLU kernel in `stable-fast` is already faster than unfused implementations, it might still have room to improve.

So I optimize the kernel ThreadBlockSize and implement a faster GELU function.

Before optimizing, on A10, speed is less than 4 it/s with 1024x1024. After optimizing, it is now 4.2 it/s.

`python3 examples/optimize_stable_diffusion_pipeline.py --model stabilityai/stable-diffusion-xl-base-1.0 --height 1024 --width 1024 --seed 0`