### PR TITLE
add sfast_extra_key to customize the cache key

### DIFF
--- a/src/sfast/jit/trace_helper.py
+++ b/src/sfast/jit/trace_helper.py
@@ -42,6 +42,8 @@ def lazy_trace(func, *, ts_compiler=None, **kwargs_):
     def wrapper(*args, **kwargs):
         nonlocal lock, traced_modules
         key = (module_to_be_traced.training, hash_arg(args), hash_arg(kwargs))
+        if "sfast_extra_key" in kwargs:
+            kwargs.pop("sfast_extra_key")
         traced_module = traced_modules.get(key)
         if traced_module is None:
             with lock:


### PR DESCRIPTION
**Proposal**: 

add a ```sfast_extra_key``` to customize the cache key.  

The current trace module key included ```hash_arg(args)``` and  ```hash_arg(kwargs)```, but some args could be set up in other ways. (e.g. by attention_processor mixin).

Enabling extra kwargs can let users easily define their own trace key.
